### PR TITLE
TODO: force 2 digits for date

### DIFF
--- a/deploy_freenas.py
+++ b/deploy_freenas.py
@@ -26,7 +26,7 @@ PASSWORD = "ReallySecurePassword"
 DOMAIN_NAME = "your_fqdn"
 PROTOCOL = 'http://'
 now = datetime.now()
-cert = "letsencrypt-%s-%s-%s" %(now.year, now.month, now.day) # TODO: force two digits for month and day
+cert = "letsencrypt-%s-%s-%s" %(now.year, now.strftime('%m'), now.strftime('%d'))
 
 # Load cert/key
 with open(PRIVATEKEY_PATH, 'r') as file:


### PR DESCRIPTION
On downloading, found that the date string line for naming the cert had a note - TODO: force 2 digits for month and day. This edit takes care of that (and makes no other changes)