### PR TITLE
Make FTP certificate optional and install it before reload if enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ privkey_path = /some/other/path
 fullchain_path = /some/other/other/path
 protocol = https://
 port = 443
+ftp_enabled = false
 ```
 
 Everything but the password is optional, and the defaults are documented in `depoy_config.example`.

--- a/deploy_config.example
+++ b/deploy_config.example
@@ -36,3 +36,6 @@ password = YourSuperSecurePassword#@#$*
 # port sets the port to use to connect.  Default is 80.  If protocol is https,
 # this MUST be set to your https port.
 # port = 443
+
+# set ftp_enabled to true if you have the FTP service enabled on your FreeNAS. Default is false.
+# ftp_enabled = true

--- a/deploy_freenas.py
+++ b/deploy_freenas.py
@@ -50,6 +50,7 @@ PRIVATEKEY_PATH = deploy.get('privkey_path',"/root/.acme.sh/" + DOMAIN_NAME + "/
 FULLCHAIN_PATH = deploy.get('fullchain_path',"/root/.acme.sh/" + DOMAIN_NAME + "/fullchain.cer")
 PROTOCOL = deploy.get('protocol','http://')
 PORT = deploy.get('port','80')
+FTP_ENABLED = deploy.getboolean('ftp_enabled',fallback=False)
 now = datetime.now()
 cert = "letsencrypt-%s-%s-%s-%s" %(now.year, now.strftime('%m'), now.strftime('%d'), ''.join(c for c in now.strftime('%X') if
 c.isdigit()))
@@ -122,23 +123,24 @@ else:
   print (r)
   sys.exit(1)
 
-# Set our cert as active for FTP plugin
-r = requests.put(
-  PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v1.0/services/ftp/',
-  verify=VERIFY,
-  auth=(USER, PASSWORD),
-  headers={'Content-Type': 'application/json'},
-  data=json.dumps({
-  "ftp_ssltls_certfile": cert,
-  }),
-)
+if FTP_ENABLED:
+  # Set our cert as active for FTP plugin
+  r = requests.put(
+    PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v1.0/services/ftp/',
+    verify=VERIFY,
+    auth=(USER, PASSWORD),
+    headers={'Content-Type': 'application/json'},
+    data=json.dumps({
+    "ftp_ssltls_certfile": cert,
+    }),
+  )
 
-if r.status_code == 200:
-  print ("Setting active certificate successful")
-else:
-  print ("Error setting active certificate!")
-  print (r)
-  sys.exit(1)
+  if r.status_code == 200:
+    print ("Setting active FTP certificate successful")
+  else:
+    print ("Error setting active FTP certificate!")
+    print (r)
+    sys.exit(1)
 
 # Reload nginx with new cert
 try:

--- a/deploy_freenas.py
+++ b/deploy_freenas.py
@@ -122,16 +122,6 @@ else:
   print (r)
   sys.exit(1)
 
-# Reload nginx with new cert
-try:
-  r = requests.post(
-    PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v1.0/system/settings/restart-httpd-all/',
-    verify=VERIFY,
-    auth=(USER, PASSWORD),
-  )
-except requests.exceptions.ConnectionError:
-  pass # This is expected when restarting the web server
-
 # Set our cert as active for FTP plugin
 r = requests.put(
   PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v1.0/services/ftp/',
@@ -149,3 +139,13 @@ else:
   print ("Error setting active certificate!")
   print (r)
   sys.exit(1)
+
+# Reload nginx with new cert
+try:
+  r = requests.post(
+    PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v1.0/system/settings/restart-httpd-all/',
+    verify=VERIFY,
+    auth=(USER, PASSWORD),
+  )
+except requests.exceptions.ConnectionError:
+  pass # This is expected when restarting the web server


### PR DESCRIPTION
* Added an "ftp_enabled" option (defaults to false) for people who do not have the FTP service enabled. (Addresses Issue #14)
* Moved the installation of the FTP certificate to before nginx is reloaded so the FTP certificate installation won't fail due to the FreeNAS API restarting.