### PR TITLE
Update for V2 API in FreeNAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # deploy-freenas
 
-deploy-freenas.py is a Python script to deploy TLS certificates to a FreeNAS server using the FreeNAS API.  This should ensure that the certificate data is properly stored in the configuration database, and that all appropriate services use this certificate.  It's intended to be called from a Let's Encrypt client like [acme.sh](https://github.com/Neilpang/acme.sh) after the certificate is issued, so that the entire process of issuance (or renewal) and deployment can be automated.
+deploy-freenas.py is a Python script to deploy TLS certificates to a FreeNAS/TrueNAS (Core) server using the FreeNAS/TrueNAS API.  This should ensure that the certificate data is properly stored in the configuration database, and that all appropriate services use this certificate.  It's intended to be called from a Let's Encrypt client like [acme.sh](https://github.com/Neilpang/acme.sh) after the certificate is issued, so that the entire process of issuance (or renewal) and deployment can be automated.
 
 # Installation
-This script can run on any machine running Python 3 that has network access to your FreeNAS server, but in most cases it's best to run it directly on the FreeNAS box.  Change to a convenient directory and run `git clone https://github.com/danb35/deploy-freenas`.
+This script can run on any machine running Python 3 that has network access to your FreeNAS/TrueNAS server, but in most cases it's best to run it directly on the FreeNAS/TrueNAS box.  Change to a convenient directory and run `git clone https://github.com/danb35/deploy-freenas`.
 
 # Usage
 
@@ -22,7 +22,13 @@ port = 443
 ftp_enabled = false
 ```
 
-Everything but the password is optional, and the defaults are documented in `depoy_config.example`.
+Everything but `password` (or `api_key`) is optional, and the defaults are documented in `depoy_config.example`.
+
+On TrueNAS (Core) 12.0 and up you should use API key authentication instead of password authentication.
+[Generate a new API token in the UI](https://www.truenas.com/docs/hub/additional-topics/api/#creating-api-keys) first, then add it as `api_key` to the config, which replaces the `password` field:
+```
+api_key = 1-DXcZ19sZoZFdGATIidJ8vMP6dxk3nHWz3XX876oxS7FospAGMQjkOft0h4itJDSP
+```
 
 Once you've prepared `deploy_config`, you can run `deploy_freenas.py`.  The intended use is that it would be called by your ACME client after issuing a certificate.  With acme.sh, for example, you'd add `--deploy-hook "/path/to/deploy_freenas.py"` to your command.
 

--- a/deploy_config.example
+++ b/deploy_config.example
@@ -1,10 +1,10 @@
 # Configuration file for deploy_freenas.py
 
 [deploy]
-# Choose one of the following authentication methods.
-# Auth via API keys is highly recommended, but can only be used in TrueNAS 12.0+.
+# Choose one of the following authentication methods, "api_key" or "password" (comment out the other one).
+# Auth via API keys is highly recommended, but is only available from TrueNAS (Core) 12.0 up.
 # You can generate a new API key in the web interface under "Settings" (upper right) > "API Keys".
-api_key = YourNewlyGeneratedAPIKey#@#$*
+# api_key = YourNewlyGeneratedAPIKey#@#$*
 # If you are on FreeNAS 11 or lower, set this to your FreeNAS root password
 password = YourSuperSecurePassword#@#$*
 

--- a/deploy_config.example
+++ b/deploy_config.example
@@ -1,8 +1,11 @@
 # Configuration file for deploy_freenas.py
 
 [deploy]
-# This is the only line that is mandatory
-# Set it to your FreeNAS root password
+# Choose one of the following authentication methods.
+# Auth via API keys is highly recommended, but can only be used in TrueNAS 12.0+.
+# You can generate a new API key in the web interface under "Settings" (upper right) > "API Keys".
+api_key = YourNewlyGeneratedAPIKey#@#$*
+# If you are on FreeNAS 11 or lower, set this to your FreeNAS root password
 password = YourSuperSecurePassword#@#$*
 
 # Everything below here is optional
@@ -10,7 +13,7 @@ password = YourSuperSecurePassword#@#$*
 # cert_fqdn specifies the FQDN used for your certificate.  Default is your system hostname
 # cert_fqdn = foo.bar.baz
 
-# connect_host specifies the hostname the script should attempt to connect to, to deploy the cert. 
+# connect_host specifies the hostname the script should attempt to connect to, to deploy the cert.
 # Default is localhost (assuming the script is running on your FreeNAS box)
 # connect_host = baz.bar.foo
 

--- a/deploy_freenas.py
+++ b/deploy_freenas.py
@@ -20,6 +20,7 @@ import os
 import sys
 import json
 import requests
+import time
 import configparser
 import socket
 from datetime import datetime, timedelta
@@ -62,28 +63,32 @@ with open(FULLCHAIN_PATH, 'r') as file:
 
 # Update or create certificate
 r = requests.post(
-  PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v1.0/system/certificate/import/',
+  PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v2.0/certificate/',
   verify=VERIFY,
   auth=(USER, PASSWORD),
   headers={'Content-Type': 'application/json'},
   data=json.dumps({
-  "cert_name": cert,
-  "cert_certificate": full_chain,
-  "cert_privatekey": priv_key,
+  "create_type": "CERTIFICATE_CREATE_IMPORTED",
+  "name": cert,
+  "certificate": full_chain,
+  "privatekey": priv_key,
   }),
 )
 
-if r.status_code == 201:
+if r.status_code == 200:
   print ("Certificate import successful")
 else:
   print ("Error importing certificate!")
   print (r)
   sys.exit(1)
 
+# Sleep for a few seconds to let the cert propagate
+time.sleep(5)
+
 # Download certificate list
 limit = {'limit': 0} # set limit to 0 to disable paging in the event of many certificates
 r = requests.get(
-  PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v1.0/system/certificate/',
+  PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v2.0/certificate/',
   verify=VERIFY,
   params=limit,
   auth=(USER, PASSWORD))
@@ -98,20 +103,25 @@ else:
 # Parse certificate list to find the id that matches our cert name
 cert_list = r.json()
 
+new_cert_data = None
 for cert_data in cert_list:
-  if cert_data['cert_name'] == cert:
+  if cert_data['name'] == cert:
     new_cert_data = cert_data
-    cert_id = cert_data['id']
+    cert_id = new_cert_data['id']
     break
+
+if not new_cert_data:
+  print ("Error searching for newly imported certificate in certificate list.")
+  sys.exit(1)
 
 # Set our cert as active
 r = requests.put(
-  PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v1.0/system/settings/',
+  PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v2.0/system/general/',
   verify=VERIFY,
   auth=(USER, PASSWORD),
   headers={'Content-Type': 'application/json'},
   data=json.dumps({
-  "stg_guicertificate": cert_id,
+  "ui_certificate": cert_id,
   }),
 )
 
@@ -125,12 +135,12 @@ else:
 if FTP_ENABLED:
   # Set our cert as active for FTP plugin
   r = requests.put(
-    PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v1.0/services/ftp/',
+    PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v2.0/ftp/',
     verify=VERIFY,
     auth=(USER, PASSWORD),
     headers={'Content-Type': 'application/json'},
     data=json.dumps({
-    "ftp_ssltls_certfile": cert,
+    "ssltls_certfile": cert,
     }),
   )
 
@@ -145,11 +155,11 @@ if FTP_ENABLED:
 cert_ids_same_san = set()
 cert_ids_expired = set()
 for cert_data in cert_list:
-  if set(cert_data['cert_san']) == set(new_cert_data['cert_san']):
+  if set(cert_data['san']) == set(new_cert_data['san']):
       cert_ids_same_san.add(cert_data['id'])
 
-  issued_date = datetime.strptime(cert_data['cert_from'], "%c")
-  lifetime = timedelta(days=cert_data['cert_lifetime'])
+  issued_date = datetime.strptime(cert_data['from'], "%c")
+  lifetime = timedelta(days=cert_data['lifetime'])
   expiration_date = issued_date + lifetime
   if expiration_date < now:
       cert_ids_expired.add(cert_data['id'])
@@ -164,7 +174,7 @@ if cert_id in cert_ids_same_san:
 # Delete expired and old certificates with same SAN from freenas
 for cid in (cert_ids_same_san | cert_ids_expired):
   r = requests.delete(
-    PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v1.0/system/certificate/' + str(cid),
+    PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v2.0/certificate/id/' + str(cid),
     verify=VERIFY,
     auth=(USER, PASSWORD),
     headers={'Content-Type': 'application/json'},
@@ -172,9 +182,9 @@ for cid in (cert_ids_same_san | cert_ids_expired):
 
   for c in cert_list:
     if c['id'] == cid:
-      cert_name = c['cert_name']
+      cert_name = c['name']
 
-  if r.status_code == 204:
+  if r.status_code == 200:
     print ("Deleting certificate " + cert_name + " successful")
   else:
     print ("Error deleting certificate " + cert_name + "!")
@@ -184,7 +194,7 @@ for cid in (cert_ids_same_san | cert_ids_expired):
 # Reload nginx with new cert
 try:
   r = requests.post(
-    PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v1.0/system/settings/restart-httpd-all/',
+    PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v2.0/system/general/ui_restart',
     verify=VERIFY,
     auth=(USER, PASSWORD),
   )


### PR DESCRIPTION
This is based on @kensand's work in #22.
It adjusts all API calls to use the RESTful v2.0 API.

Further changes to the ones @kensand already did were adjusting the new API call added in #19 which removes the old certs, and adjusting the new error message in line 114 to match the style of the other error messages.

I've tested this several time on my NAS on TrueNAS-12.0-BETA and it seems to work fine.

Replaces #22