### PR TITLE
 Correctly reload WebUI, print returned message on request errors, fix README reload cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ On TrueNAS (Core) 12.0 and up you should use API key authentication instead of p
 api_key = 1-DXcZ19sZoZFdGATIidJ8vMP6dxk3nHWz3XX876oxS7FospAGMQjkOft0h4itJDSP
 ```
 
-Once you've prepared `deploy_config`, you can run `deploy_freenas.py`.  The intended use is that it would be called by your ACME client after issuing a certificate.  With acme.sh, for example, you'd add `--deploy-hook "/path/to/deploy_freenas.py"` to your command.
+Once you've prepared `deploy_config`, you can run `deploy_freenas.py`.  The intended use is that it would be called by your ACME client after issuing a certificate.  With acme.sh, for example, you'd add `--reloadcmd "/path/to/deploy_freenas.py"` to your command.
 
 There is an optional paramter, `-c` or `--config`, that lets you specify the path to your configuration file. By default the script will try to use `deploy_config` in the script working directoy:
 

--- a/deploy_freenas.py
+++ b/deploy_freenas.py
@@ -96,7 +96,7 @@ if r.status_code == 200:
   print ("Certificate import successful")
 else:
   print ("Error importing certificate!")
-  print (r)
+  print (r.text)
   sys.exit(1)
 
 # Sleep for a few seconds to let the cert propagate
@@ -114,7 +114,7 @@ if r.status_code == 200:
   print ("Certificate list successful")
 else:
   print ("Error listing certificates!")
-  print (r)
+  print (r.text)
   sys.exit(1)
 
 # Parse certificate list to find the id that matches our cert name
@@ -144,7 +144,7 @@ if r.status_code == 200:
   print ("Setting active certificate successful")
 else:
   print ("Error setting active certificate!")
-  print (r)
+  print (r.text)
   sys.exit(1)
 
 if FTP_ENABLED:
@@ -161,7 +161,7 @@ if FTP_ENABLED:
     print ("Setting active FTP certificate successful")
   else:
     print ("Error setting active FTP certificate!")
-    print (r)
+    print (r.text)
     sys.exit(1)
 
 # Get expired and old certs with same SAN
@@ -199,14 +199,20 @@ for cid in (cert_ids_same_san | cert_ids_expired):
     print ("Deleting certificate " + cert_name + " successful")
   else:
     print ("Error deleting certificate " + cert_name + "!")
-    print (r)
+    print (r.text)
     sys.exit(1)
 
 # Reload nginx with new cert
+# If everything goes right, the request fails with a ConnectionError
 try:
-  r = session.post(
+  r = session.get(
     PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v2.0/system/general/ui_restart',
     verify=VERIFY
   )
+  # If we've arrived here, something went wrong
+  print ("Error reloading WebUI!")
+  print (r.text)
+  sys.exit(1)
 except requests.exceptions.ConnectionError:
-  pass # This is expected when restarting the web server
+  print ("Reloading WebUI successful")
+  print ("deploy_freenas.py executed successfully")


### PR DESCRIPTION
## Problems
* The README.md suggests using `--deploy-hook` with acme.sh to call `deploy_freenas.py`, however this option is only to be used for acme.sh's integrated deploy mechanisms. For custom scipts like this one, there's `--reloadcmd`. See #27 
* Currently the script only prints the HTTP status code if a request fails. However TrueNAS itself also returns some error message or more with it, which may be useful for debugging. See #28 
* The UI doesn't actually restart after the cert is uploaded. The script is using the wrong request method, it should be a GET not a POST. See #25 

## Changes
* Change `--deploy-hook` to `--reloadcmd` in the README.md.
* Always print `r.text` (Full response returned, possibly with useful debug information) instead of only `r` (only status code) on request errors.
* Switch method for `/api/v2.0/system/general/ui_restart` to GET, which now successfully restarts the UI.

I have tested changes 2 and 3, both seem to to work fine.

Fixes #27 
Fixes #25 
Fixes #28 