### PR TITLE
Fix FTP certificate deployment

### DIFF
--- a/deploy_freenas.py
+++ b/deploy_freenas.py
@@ -153,7 +153,7 @@ if FTP_ENABLED:
     PROTOCOL + FREENAS_ADDRESS + ':' + PORT + '/api/v2.0/ftp/',
     verify=VERIFY,
     data=json.dumps({
-      "ssltls_certfile": cert,
+      "ssltls_certificate": cert_id,
     }),
   )
 


### PR DESCRIPTION
The FTP plugin now takes a certificate ID instad of a certificate file