### PR TITLE
checking for CSR before remove

### DIFF
--- a/deploy_freenas.py
+++ b/deploy_freenas.py
@@ -189,11 +189,12 @@ for cert_data in cert_list:
   if set(cert_data['san']) == set(new_cert_data['san']):
       cert_ids_same_san.add(cert_data['id'])
 
-  issued_date = datetime.strptime(cert_data['from'], "%c")
-  lifetime = timedelta(days=cert_data['lifetime'])
-  expiration_date = issued_date + lifetime
-  if expiration_date < now:
-      cert_ids_expired.add(cert_data['id'])
+  if not cert_data['cert_type_CSR']:
+      issued_date = datetime.strptime(cert_data['from'], "%c")
+      lifetime = timedelta(days=cert_data['lifetime'])
+      expiration_date = issued_date + lifetime
+      if expiration_date < now:
+          cert_ids_expired.add(cert_data['id'])
 
 # Remove new cert_id from lists
 if cert_id in cert_ids_expired:


### PR DESCRIPTION
Hello. I noticed that when there is a CSR in the list of certificates, the script throws an exception:

Traceback (most recent call last):
  File "./deploy_freenas.py", line 192, in <module>
    issued_date = datetime.strptime(cert_data['from'], "%c")
TypeError: strptime() argument 1 must be str, not None

I added a check on whether the certificate being checked is a CSR and if so then don't add it to the expired list

P.S. I hope I didn't break anything too much and my PR will be useful, this is my first PR