### PR TITLE
Add support for S3 service

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ privkey_path = /some/other/path
 fullchain_path = /some/other/other/path
 protocol = https://
 port = 443
+s3_enabled = false
 ftp_enabled = false
 webdav_enabled = false
 cert_base_name = letsencrypt

--- a/deploy_config.example
+++ b/deploy_config.example
@@ -40,6 +40,9 @@ password = YourSuperSecurePassword#@#$*
 # this MUST be set to your https port.
 # port = 443
 
+# set s3_enabled to true if you have the S3 service enabled on your FreeNAS. Default is false.
+# s3_enabled = true
+
 # set ftp_enabled to true if you have the FTP service enabled on your FreeNAS. Default is false.
 # ftp_enabled = true
 

--- a/deploy_freenas.py
+++ b/deploy_freenas.py
@@ -53,6 +53,7 @@ PRIVATEKEY_PATH = deploy.get('privkey_path',"/root/.acme.sh/" + DOMAIN_NAME + "/
 FULLCHAIN_PATH = deploy.get('fullchain_path',"/root/.acme.sh/" + DOMAIN_NAME + "/fullchain.cer")
 PROTOCOL = deploy.get('protocol','http://')
 PORT = deploy.get('port','80')
+S3_ENABLED = deploy.getboolean('s3_enabled',fallback=False)
 FTP_ENABLED = deploy.getboolean('ftp_enabled',fallback=False)
 WEBDAV_ENABLED = deploy.getboolean('webdav_enabled',fallback=False)
 CERT_BASE_NAME = deploy.get('cert_base_name','letsencrypt')
@@ -151,6 +152,23 @@ else:
   print ("Error setting active certificate!")
   print (r.text)
   sys.exit(1)
+
+if S3_ENABLED:
+  # Set our cert as active for S3 plugin
+  r = session.put(
+    BASE_URL + '/api/v2.0/s3/',
+    verify=VERIFY,
+    data=json.dumps({
+      "certificate": cert_id,
+    }),
+  )
+
+  if r.status_code == 200:
+    print ("Setting active S3 certificate successful")
+  else:
+    print ("Error setting active S3 certificate!")
+    print (r)
+    sys.exit(1)
 
 if FTP_ENABLED:
   # Set our cert as active for FTP plugin

--- a/deploy_freenas.py
+++ b/deploy_freenas.py
@@ -242,6 +242,21 @@ for cid in (cert_ids_same_san | cert_ids_expired):
     print (r.text)
     sys.exit(1)
 
+# Reload minio with new cert
+if S3_ENABLED:
+  r = session.post(
+    BASE_URL + '/api/v2.0/service/restart',
+    verify=VERIFY,
+    data=json.dumps({
+      "service": "s3",
+    }),
+  )
+  if r.status_code == 200:
+    print ("Reloading S3 service successful")
+  else:
+    print ("Error reloading S3 service!")
+    print (r.text)
+    
 # Reload nginx with new cert
 # If everything goes right in 12.0-U3 and later, it returns 200
 # If everything goes right with an earlier release, the request


### PR DESCRIPTION
This PR adds support for changing the certificate on the S3 service (minio). It's basically #26 from [mikeh2020](https://github.com/mikeh2020/deploy-freenas/tree/s3_support) redone to fit on the latest master here.