### PR TITLE
feat: update scale apps their certificate id

### DIFF
--- a/deploy_config.example
+++ b/deploy_config.example
@@ -49,6 +49,9 @@ password = YourSuperSecurePassword#@#$*
 # set webdav_enabled to true if you have the WEBDAV service enabled on your FreeNAS. Default is false.
 # webdav_enabled = true
 
+# set apps_enabled to true if you want to update your TrueNAS SCALE chart applications to use the new certificate. Default is false.
+# apps_enabled = true
+
 # Certificates will be given a name with a timestamp, by default it will be
 # letsencrypt-yyyy-mm-dd-hhmmss.  You can change the first part if you like.
 # cert_base_name = something_else


### PR DESCRIPTION
This looks trough the deployed scale apps and checks if the ingress is enabled and TLS is active. If so, update the certificate ID to the new one.