### PR TITLE
Add `ui_certificate_enabled` to optionally disable updating UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ privkey_path = /some/other/path
 fullchain_path = /some/other/other/path
 protocol = https://
 port = 443
+ui_certificate_enabled = false
 s3_enabled = false
 ftp_enabled = false
 webdav_enabled = false

--- a/deploy_config.example
+++ b/deploy_config.example
@@ -40,6 +40,9 @@ password = YourSuperSecurePassword#@#$*
 # this MUST be set to your https port.
 # port = 443
 
+# set ui_certificate_enabled to false if you want to skip using the new cerificate for the UI. Default is true.
+# ui_certificate_enabled = false
+
 # set s3_enabled to true if you have the S3 service enabled on your FreeNAS. Default is false.
 # s3_enabled = true
 


### PR DESCRIPTION
This change adds an optional `ui_certificate_enabled` option which can be used to skip installing the certificate as the system's UI certificate.

In my use case I was hoping to use this program to upload extra certificates which will be used by deployed app charts.