### PR TITLE
Add `apps_only_matching_san` to optionally enable only updating app certificates with matching san

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ ui_certificate_enabled = false
 s3_enabled = false
 ftp_enabled = false
 webdav_enabled = false
+apps_enabled = false
+apps_only_matching_san = false
 cert_base_name = letsencrypt
 ```
 

--- a/deploy_config.example
+++ b/deploy_config.example
@@ -55,6 +55,9 @@ password = YourSuperSecurePassword#@#$*
 # set apps_enabled to true if you want to update your TrueNAS SCALE chart applications to use the new certificate. Default is false.
 # apps_enabled = true
 
+# only update TrueNAS SCALE chart applications where the san of the current and the new cert matches. Default is false.
+#apps_only_matching_san = true
+
 # Certificates will be given a name with a timestamp, by default it will be
 # letsencrypt-yyyy-mm-dd-hhmmss.  You can change the first part if you like.
 # cert_base_name = something_else


### PR DESCRIPTION
This change adds an optional apps_only_matching_san option to use to update only app certificates with matching san.


I use multiple different certificates within my truenas scale app charts. Know it only updates the "right" apps. Before, it overrides all app certificates with the latest uploaded cert.