### PR TITLE
Bug fix: deletion of old certs fails

### DIFF
--- a/deploy_freenas.py
+++ b/deploy_freenas.py
@@ -210,7 +210,7 @@ cert_ids_same_san = set()
 cert_ids_expired = set()
 for cert_data in cert_list:
   if set(cert_data['san']) == set(new_cert_data['san']):
-      if cert_data['name'].startswith("CERT_BASE_NAME"):
+      if cert_data['name'].startswith(CERT_BASE_NAME):
         cert_ids_same_san.add(cert_data['id'])
 
   if not cert_data['cert_type_CSR']:


### PR DESCRIPTION
Remove unnecessary double quotation marks.
Fixes: https://github.com/danb35/deploy-freenas/issues/65
