### PR TITLE
Configurable HTTP port for version information.

### DIFF
--- a/deploy_config_truenas.example
+++ b/deploy_config_truenas.example
@@ -21,6 +21,9 @@ api_key = YourNewlyGeneratedAPIKey#@#$*
 # 80 if protocol is ws, and 443 if protocol is wss.
 # connect_port = 81
 
+# connect_port_http specifies the HTTP port on which the script should fetch API version infomation.  Defaults to 80.
+# connect_port_http = 81
+
 # protocol specifies the protocol used to connect to the API.  Default is ws.
 # Set to wss for TrueNAS 25.04 and later
 # protocol = wss

--- a/deploy_truenas.py
+++ b/deploy_truenas.py
@@ -60,8 +60,11 @@ logger.setLevel(getattr(logging, LOG.upper(), logging.INFO))
 # Initialize variables
 CONNECT_PORT = ""
 CONNECT_PORT = deploy.get('connect_port', "")
+CONNECT_PORT_HTTP = deploy.get('connect_port_http', "")
 if CONNECT_PORT != "":
     CONNECT_PORT = ":" + CONNECT_PORT
+if CONNECT_PORT_HTTP != "":
+    CONNECT_PORT_HTTP = ":" + CONNECT_PORT_HTTP
 API_KEY = deploy.get('api_key')
 PROTOCOL = deploy.get('protocol', "ws")
 CONNECT_HOST = deploy.get('connect_host', "localhost")
@@ -145,7 +148,7 @@ valid_versions = []
 invalid_response = False
 
 try:
-    response = requests.get(f"http://{CONNECT_HOST}/api/versions", timeout=10)
+    response = requests.get(f"http://{CONNECT_HOST}{CONNECT_PORT_HTTP}/api/versions", timeout=10)
     response.raise_for_status()
 
     data = response.json()


### PR DESCRIPTION
The script attempts to fetch API version information with HTTP on port 80. If TrueNAS listens to another HTTP port, this fails and the legacy client is used instead of the JSON RPC client.

This change adds a configuration key, connect_port_http, to allow the port to be overridden.