### PR TITLE
Ping TrueNAS while waiting for update job to complete, to keep web socket alive.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 deploy_config
+.idea

--- a/deploy_truenas.py
+++ b/deploy_truenas.py
@@ -225,7 +225,6 @@ with Client(
             logger.debug(app_config)
             if 'ix_certificates' in app_config and app_config['ix_certificates']:
                 try:
-                    result=c.call("app.update", app["id"], {"values": {"network": {"certificate_id": cert_id}}}, job=True)
                     logger.info(f"Updating application {app['id']}.")
                     port_number = None
                     try:


### PR DESCRIPTION
An app update can take minutes and during this time the websocket often dies.

This fix keeps the web socket alive by pinging TrueNAS in a loop, waiting for update job to complete.

Also includes changes in pull request 87:

Retain web port number when updating app certificate.
For some reason, the configured web port is lost when the app is updated with a new certificate. Using TrueNAS Scale 25.04.2.4.
This is a workaround that fetches the port number and applies it with the certificate. Seems to fix the problem.
